### PR TITLE
Moving repo from Harshal's repo to DLT-Demo

### DIFF
--- a/roles/app/defaults/main.yml
+++ b/roles/app/defaults/main.yml
@@ -1,3 +1,3 @@
-metarapp_repo: https://github.com/hdharia/metarapp.git
+metarapp_repo: https://github.com/DLT-Demo/metarapp.git
 http_port: 8080
 https_port: 8443


### PR DESCRIPTION
I'm waiting for GitHub to provide updated license so I've forked Harshal's repo and using DLT-Demo.